### PR TITLE
Abstract the cryptography code out into its own module

### DIFF
--- a/cryptographer.py
+++ b/cryptographer.py
@@ -90,51 +90,6 @@ def variables(arguments):
         verbose = 0
     return function, message, output_file, verbose, password, keylength
 
-
-def phase1_crypto(password, nonce, rnum, message, function, verbose):
-    """ Phase 1 encrypts every character in the message by shifting it through
-    the UTF-8 alphabet by a number derived from the character of the hashed
-    password for the current round and the nonce."""
-    encrypted_message = ""
-    for index, letter in enumerate(message):
-        offset = int(ord(password[index % (password.index('') - 1)])) * \
-                 ord(nonce)
-        if function == "encrypt":
-            encrypted_char = chr(int(ord(letter) + offset) % 55000)
-        elif function == "decrypt":
-            encrypted_char = chr(int(ord(letter) - offset) % 55000)
-        encrypted_message = encrypted_message + encrypted_char
-    message = encrypted_message
-    if verbose == 2:
-        print("Round " + str(rnum) + "-- Phase 1: " + message)
-    return message
-
-
-def phase2_crypto(password, nonce, rnum, message, char, function, verbose):
-    """ Phase 2 encrypts every fifth character in the message, starting with
-    the one in the position of the round number modulus 5, by shifting it by
-    a number derived from the round number, nonce, and the ordinal position of
-    the current round's character from the hashed password devided by the
-    length of the password."""
-    rnonce = rnum * ord(nonce)
-    encrypted_message = ""
-    for index, letter in enumerate(message):
-        if index % 5 == rnum % 5:
-            pass_place = int(ord(char) / len(password))
-            if function == "encrypt":
-                encrypted_char = chr((ord(letter) + (pass_place * rnonce)) % 55000)
-            elif function == "decrypt":
-                encrypted_char = chr((ord(letter) - (pass_place * rnonce)) % 55000)
-            encrypted_message = encrypted_message + encrypted_char
-        else:
-            encrypted_message = encrypted_message + letter
-    message = encrypted_message
-    if verbose == 2:
-        print("Round " + str(rnum) + "-- Phase 2: " + message)
-    return message
-
-
-
 def main(arguments):
     """Performs all of the nessacerry setup and clean up to encrypt or
     decrypt a message based on the -e or -d arugments.
@@ -152,10 +107,9 @@ def main(arguments):
 
     password = libcryptographer.hash_pass(password, keylength)
     for rnum, char in enumerate(password):
-        message = phase1_crypto(password, nonce, rnum, message, function,
-                                verbose)
-        message = phase2_crypto(password, nonce, rnum, message, char,
-                                function, verbose)
+        message = libcryptographer.phase1_crypto(password, nonce, rnum, message, function)
+        message = libcryptographer.phase2_crypto(password, nonce, rnum, message, char,
+                                function)
         if verbose > 0:
             print((rnum / len(password)) * 100, "% Complete.")
 

--- a/cryptographer.py
+++ b/cryptographer.py
@@ -141,6 +141,9 @@ def main(arguments):
     Also handles writing to the output file or standard out."""
     function, message, output_file, verbose, password, keylength = \
         variables(arguments)
+
+    libcryptographer.set_verbosity(verbose)
+    
     if function == "encrypt":
         nonce = libcryptographer.generate_nonce()
     elif function == "decrypt":

--- a/libcryptographer.py
+++ b/libcryptographer.py
@@ -1,73 +1,88 @@
 import time
 
-verbose = 0
+class LibCryptographer(object):
+    verbose = 0
+    function = "encrypt"
+    
+    def set_verbosity(this, v):
+        """ Set the verbosity level. 0 is none, 2 is highest and will print out the most debug information """
+        this.verbose = v
 
-def set_verbosity(v):
-    """ Set the verbosity level. 0 is none, 2 is highest and will print out the most debug information """
-    verbose = v
+    def set_function(this, f):
+        """ Set whether we should operate in encrypt or decrypt mode. encrypt is the default. """
+        this.function = f
+        
+    def generate_nonce(this):
+        """ Uses the current time to generate a unique nonce """
+        return chr(int(time.time() * 10000000) % 55000)
+    
+    def hash_pass(this, password, keylength):
+        """ The password is hashed to ensure that the resulting hashed password
+        will meet the keylength requirements given by the user. This allows the
+        user to have a secure key without having to remember a long password."""
+        if this.verbose == 2:
+            print("Unhashed password: " + password)
+        t1 = len(password) + 2
+        while len(str(t1)) < (int(keylength) * 4):
+            for i in password:
+                t1 = t1 * ((len(password) + 2) ** ord(i))
+        p = ""
+        for i in zip(*[iter(str(t1))] * 3):
+            n0 = int(i[0]) + 2
+            n1 = int(i[1]) + 2
+            n2 = int(i[2]) + 2
+            p = p + chr(((n0 ** n1) ** n2) % 55000 + 48)
+        password = p[:int(keylength)]
+        if this.verbose == 2:
+            print("Hashed password: " + password)
+        this.password = password
+        return password
 
-def generate_nonce():
-    """ Uses the current time to generate a unique nonce """
-    return chr(int(time.time() * 10000000) % 55000)
-
-def hash_pass(password, keylength):
-    """ The password is hashed to ensure that the resulting hashed password
-    will meet the keylength requirements given by the user. This allows the
-    user to have a secure key without having to remember a long password."""
-    if verbose == 2:
-        print("Unhashed password: " + password)
-    t1 = len(password) + 2
-    while len(str(t1)) < (int(keylength) * 4):
-        for i in password:
-            t1 = t1 * ((len(password) + 2) ** ord(i))
-    p = ""
-    for i in zip(*[iter(str(t1))] * 3):
-        n0 = int(i[0]) + 2
-        n1 = int(i[1]) + 2
-        n2 = int(i[2]) + 2
-        p = p + chr(((n0 ** n1) ** n2) % 55000 + 48)
-    password = p[:int(keylength)]
-    if verbose == 2:
-        print("Hashed password: " + password)
-    return password
-
-def phase1_crypto(password, nonce, rnum, message, function):
-    """ Phase 1 encrypts every character in the message by shifting it through
-    the UTF-8 alphabet by a number derived from the character of the hashed
-    password for the current round and the nonce."""
-    encrypted_message = ""
-    for index, letter in enumerate(message):
-        offset = int(ord(password[index % (password.index('') - 1)])) * \
-                 ord(nonce)
-        if function == "encrypt":
-            encrypted_char = chr(int(ord(letter) + offset) % 55000)
-        elif function == "decrypt":
-            encrypted_char = chr(int(ord(letter) - offset) % 55000)
-        encrypted_message = encrypted_message + encrypted_char
-    message = encrypted_message
-    if verbose == 2:
-        print("Round " + str(rnum) + "-- Phase 1: " + message)
-    return message
-
-def phase2_crypto(password, nonce, rnum, message, char, function):
-    """ Phase 2 encrypts every fifth character in the message, starting with
-    the one in the position of the round number modulus 5, by shifting it by
-    a number derived from the round number, nonce, and the ordinal position of
-    the current round's character from the hashed password devided by the
-    length of the password."""
-    rnonce = rnum * ord(nonce)
-    encrypted_message = ""
-    for index, letter in enumerate(message):
-        if index % 5 == rnum % 5:
-            pass_place = int(ord(char) / len(password))
+    def phase1_crypto(this, nonce, rnum, message, function):
+        """ Phase 1 encrypts every character in the message by shifting it through
+        the UTF-8 alphabet by a number derived from the character of the hashed
+        password for the current round and the nonce."""
+        encrypted_message = ""
+        for index, letter in enumerate(message):
+            offset = int(ord(this.password[index % (this.password.index('') - 1)])) * ord(nonce)
             if function == "encrypt":
-                encrypted_char = chr((ord(letter) + (pass_place * rnonce)) % 55000)
+                encrypted_char = chr(int(ord(letter) + offset) % 55000)
             elif function == "decrypt":
-                encrypted_char = chr((ord(letter) - (pass_place * rnonce)) % 55000)
+                encrypted_char = chr(int(ord(letter) - offset) % 55000)
             encrypted_message = encrypted_message + encrypted_char
-        else:
-            encrypted_message = encrypted_message + letter
-    message = encrypted_message
-    if verbose == 2:
-        print("Round " + str(rnum) + "-- Phase 2: " + message)
-    return message
+        message = encrypted_message
+        if this.verbose == 2:
+            print("Round " + str(rnum) + "-- Phase 1: " + message)
+        return message
+
+    def phase2_crypto(this, nonce, rnum, message, char, function):
+        """ Phase 2 encrypts every fifth character in the message, starting with
+        the one in the position of the round number modulus 5, by shifting it by
+        a number derived from the round number, nonce, and the ordinal position of
+        the current round's character from the hashed password devided by the
+        length of the password."""
+        rnonce = rnum * ord(nonce)
+        encrypted_message = ""
+        for index, letter in enumerate(message):
+            if index % 5 == rnum % 5:
+                pass_place = int(ord(char) / len(this.password))
+                if function == "encrypt":
+                    encrypted_char = chr((ord(letter) + (pass_place * rnonce)) % 55000)
+                elif function == "decrypt":
+                    encrypted_char = chr((ord(letter) - (pass_place * rnonce)) % 55000)
+                encrypted_message = encrypted_message + encrypted_char
+            else:
+                encrypted_message = encrypted_message + letter
+        message = encrypted_message
+        if this.verbose == 2:
+            print("Round " + str(rnum) + "-- Phase 2: " + message)
+        return message
+
+    def perform_rounds(this, nonce, message, function):
+        """ This is the core encryption/decryption algorithm, it performs a series of rounds of the phase1 and phase2 functions to encypher the text. """
+        for rnum, char in enumerate(this.password):
+            message = this.phase1_crypto(nonce, rnum, message, function)
+            message = this.phase2_crypto(nonce, rnum, message, char, function)
+            if this.verbose > 0:
+                print((rnum / len(this.password)) * 100, "% Complete.")
+        return message

--- a/libcryptographer.py
+++ b/libcryptographer.py
@@ -30,3 +30,44 @@ def hash_pass(password, keylength):
     if verbose == 2:
         print("Hashed password: " + password)
     return password
+
+def phase1_crypto(password, nonce, rnum, message, function):
+    """ Phase 1 encrypts every character in the message by shifting it through
+    the UTF-8 alphabet by a number derived from the character of the hashed
+    password for the current round and the nonce."""
+    encrypted_message = ""
+    for index, letter in enumerate(message):
+        offset = int(ord(password[index % (password.index('') - 1)])) * \
+                 ord(nonce)
+        if function == "encrypt":
+            encrypted_char = chr(int(ord(letter) + offset) % 55000)
+        elif function == "decrypt":
+            encrypted_char = chr(int(ord(letter) - offset) % 55000)
+        encrypted_message = encrypted_message + encrypted_char
+    message = encrypted_message
+    if verbose == 2:
+        print("Round " + str(rnum) + "-- Phase 1: " + message)
+    return message
+
+def phase2_crypto(password, nonce, rnum, message, char, function):
+    """ Phase 2 encrypts every fifth character in the message, starting with
+    the one in the position of the round number modulus 5, by shifting it by
+    a number derived from the round number, nonce, and the ordinal position of
+    the current round's character from the hashed password devided by the
+    length of the password."""
+    rnonce = rnum * ord(nonce)
+    encrypted_message = ""
+    for index, letter in enumerate(message):
+        if index % 5 == rnum % 5:
+            pass_place = int(ord(char) / len(password))
+            if function == "encrypt":
+                encrypted_char = chr((ord(letter) + (pass_place * rnonce)) % 55000)
+            elif function == "decrypt":
+                encrypted_char = chr((ord(letter) - (pass_place * rnonce)) % 55000)
+            encrypted_message = encrypted_message + encrypted_char
+        else:
+            encrypted_message = encrypted_message + letter
+    message = encrypted_message
+    if verbose == 2:
+        print("Round " + str(rnum) + "-- Phase 2: " + message)
+    return message

--- a/libcryptographer.py
+++ b/libcryptographer.py
@@ -1,0 +1,32 @@
+import time
+
+verbose = 0
+
+def set_verbosity(v):
+    """ Set the verbosity level. 0 is none, 2 is highest and will print out the most debug information """
+    verbose = v
+
+def generate_nonce():
+    """ Uses the current time to generate a unique nonce """
+    return chr(int(time.time() * 10000000) % 55000)
+
+def hash_pass(password, keylength):
+    """ The password is hashed to ensure that the resulting hashed password
+    will meet the keylength requirements given by the user. This allows the
+    user to have a secure key without having to remember a long password."""
+    if verbose == 2:
+        print("Unhashed password: " + password)
+    t1 = len(password) + 2
+    while len(str(t1)) < (int(keylength) * 4):
+        for i in password:
+            t1 = t1 * ((len(password) + 2) ** ord(i))
+    p = ""
+    for i in zip(*[iter(str(t1))] * 3):
+        n0 = int(i[0]) + 2
+        n1 = int(i[1]) + 2
+        n2 = int(i[2]) + 2
+        p = p + chr(((n0 ** n1) ** n2) % 55000 + 48)
+    password = p[:int(keylength)]
+    if verbose == 2:
+        print("Hashed password: " + password)
+    return password

--- a/t/t1
+++ b/t/t1
@@ -1,0 +1,1 @@
+hello world

--- a/t/t2
+++ b/t/t2
@@ -1,0 +1,1 @@
+abcabcabca

--- a/t/t3
+++ b/t/t3
@@ -1,0 +1,1 @@
+alphabet

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,12 @@
+python3 cryptographer.py -e -p password1 -k 50 -i t/t1 -o t/t1.enc
+python3 cryptographer.py -e -p pass123321132 -k 64 -i t/t2 -o t/t2.enc
+python3 cryptographer.py -e -p thisisapassword -k 400 -i t/t3 -o t/t3.enc
+
+python3 cryptographer.py -d -p password1 -k 50 -i t/t1.enc -o t/t1.dec
+python3 cryptographer.py -d -p pass123321132 -k 64 -i t/t2.enc -o t/t2.dec
+python3 cryptographer.py -d -p thisisapassword -k 400 -i t/t3.enc -o t/t3.dec
+
+echo "performing diff test"
+diff t/t1 t/t1.dec 
+diff t/t2 t/t2.dec 
+diff t/t3 t/t3.dec 


### PR DESCRIPTION
This pull request abstracts the cryptography code into a module of its own: libcryptographer.py.

I also created a small test script to ensure that doing this large refactoring didn't break the crypto code itself: It still encrypts and decrypts cleanly and correctly.

Now cryptographer.py serves as an example of how to use libcryptographer:

First instantiate the object and set it up:

    crypt = libcryptographer.LibCryptographer()
    crypt.set_verbosity(verbose)
    crypt.set_function(function)

Then either generate a nonce or parse it from an encrypted message:

    if function == "encrypt":
        nonce = crypt.generate_nonce()
    elif function == "decrypt":
        nonce = message[0]
        message = message[1:]

Note. I chose not to include nonces inside the LibCryptographer object itself - I believe it is safer that the programmer manage them themselves as in the advice from libnacl http://nacl.cr.yp.to/box.html

Then you hash the password, and perform the encryption/decryption rounds. This gives the message back:

    crypt.hash_pass(password, keylength)
    message = crypt.perform_rounds(nonce, message, function)

It should be easy to use this as a library in other programs, I hope this is useful to you!